### PR TITLE
Add profile file to autolaunch ublue-firstboot on first login

### DIFF
--- a/etc/profile.d/ublue-firstboot.sh
+++ b/etc/profile.d/ublue-firstboot.sh
@@ -1,0 +1,6 @@
+if test "$(id -u)" -gt "0" && test -d "$HOME"; then
+    if test ! -e "$HOME"/.config/ublue/firstboot-done; then
+    	mkdir -p "$HOME"/.config/ublue/
+		/usr/bin/ublue-firstboot && touch "$HOME"/.config/ublue/firstboot-done
+    fi
+fi

--- a/etc/skel.d/.config/autostart/ublue-firstboot.desktop
+++ b/etc/skel.d/.config/autostart/ublue-firstboot.desktop
@@ -1,8 +1,0 @@
-[Desktop Entry]
-Name=Ublue Desktop FirstBoot Setup
-Comment=Sets up Ublue Desktop Correctly On FirstBoot
-Exec=/usr/bin/ublue-firstboot
-Icon=org.gnome.Terminal
-Type=Application
-Categories=Utility;System;
-Name[en_US]=startup

--- a/ublue-firstboot
+++ b/ublue-firstboot
@@ -65,7 +65,7 @@ echo "# Installing GNOME Core Tools"
         org.gnome.baobab \
         org.gnome.clocks \
         org.gnome.eog \
-        org.gnome.font-viewer  
+        org.gnome.font-viewer
 if [ "$?" != 0 ] ; then
         zenity --error \
           --text="Installing Calculator Failed"
@@ -128,7 +128,7 @@ fi
 echo "100"
 
 echo "# Reticulating Final Splines"
-rm ~/.config/autostart/ublue-firstboot.desktop
+touch ~/.config/ublue/firstboot-done
 ) |
         zenity --progress --title="uBlue Desktop Firstboot" --percentage=0 --auto-close --no-cancel --width=300
 


### PR DESCRIPTION
This should ensure that the ublue-firstboot is ran only on the first login of the user, after the rebase

Signed-off-by: Luca Di Maio <luca.dimaio1@gmail.com>